### PR TITLE
add an invalidate cronjob to invalidate expired transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor/
 logs/
 bin/
+api_logs/
+invalidator_logs/

--- a/Dockerfile.invalidator
+++ b/Dockerfile.invalidator
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o bin/api ./cmd/api/main.go
+RUN go build -o bin/invalidator ./cmd/invalidator/main.go
 
 
 # Final stage
@@ -12,10 +12,10 @@ FROM alpine:latest
 
 WORKDIR /app
 
-COPY --from=builder /app/bin/api /usr/local/bin/api
+COPY --from=builder /app/bin/invalidator /usr/local/bin/invalidator
 
-RUN mkdir -p /var/log/api
+RUN mkdir -p /var/log/invalidator
 COPY config/ ./
 
 
-CMD ["api"]
+CMD ["invalidator"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ In each handler will have a error mapping, to map a internal error to a external
 3. **PostgreSQL**: Used as the database backend, with two databases:
    - **account_db**: Contains `account_tab` and `fund_movement_tab`.
    - **transaction_db**: Contains `transaction_tab`.
+4. Invalidator. It's a cronjob runs every 10 minutes, to load expired transactions in pending and processing status, and call Cancel to these transaction. If Cancel success, move them to Failed. If too many pending transactions, that means system have some issue.
 
 ### Database Schemas
 
@@ -198,6 +199,8 @@ For Account_tab. I maintained
   - `transaction_status` (INT)
   - `created_at` (TIMESTAMP)
   - `updated_at` (TIMESTAMP)
+  - `expired_at` (TIMESTAMP)
+
 
 ### System structure
 

--- a/cmd/invalidator/main.go
+++ b/cmd/invalidator/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"main/common/config"
+	"main/common/db"
+	"main/common/log"
+	"main/common/recovery"
+	"main/internal/account"
+	"main/internal/transaction"
+	"main/model"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+func main() {
+	log.Init()
+	defer log.Cleanup()
+	config.Init()
+
+	ticker := time.NewTicker(time.Minute * time.Duration(viper.GetInt(config.ConfigKeyInvalidateInterval)))
+	defer ticker.Stop()
+	txnDB, err := db.GetTransactionDB()
+	if err != nil {
+		panic("Could not initialize transaction database")
+	}
+	accDB, err := db.GetAccountDBClient()
+	if err != nil {
+		panic("Could not initialize account database")
+	}
+	transactionRepo := transaction.NewRepository(txnDB)
+	accTCC := account.NewTCCService(accDB)
+	ctx := context.Background()
+
+	go func() {
+		recovery.GoRecovery()
+
+		for {
+			select {
+			case <-ticker.C:
+				log.GetSugger().Info("start to invalidate expired transaction")
+				// Run scan jog
+				transactions, err := transactionRepo.QueryExpiredTransactions(ctx)
+				if err != nil {
+					log.GetSugger().Error("query expired transaction error", "err", err)
+				}
+
+				log.GetSugger().Info("get expored transactions", "transactions", transactions)
+
+				for _, txn := range transactions {
+					go func() {
+						if err := accTCC.Cancel(ctx, txn.TransactionID); err != nil && err != account.ErrEmptyRollback {
+							log.GetSugger().Error("failed to cancel", "txn", txn.TransactionID)
+
+						}
+
+						if err := transactionRepo.UpdateTransactionStatus(ctx, txn.TransactionID, model.Failed); err != nil {
+							log.GetSugger().Error("failed to invalidate transaction", "txn", txn.TransactionID)
+						}
+
+						log.GetSugger().Info("auto invalicated expired transaction", "txn", txn.TransactionID)
+					}()
+				}
+			}
+		}
+	}()
+
+	log.GetSugger().Info("start invalidator")
+
+	select {}
+}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -10,6 +10,8 @@ const (
 	ConfigKeyMaxRetries               = "max_retries"
 	ConfigKeyCreateTransactionTimeout = "create_transaction_timeout"
 	ConfigKeyTryTimeout               = "try_timeout"
+	ConfigKeyTransactionExpiration    = "transaction_expiration"
+	ConfigKeyInvalidateInterval       = "invalidate_interval_minutes"
 )
 
 func Init() {

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -16,7 +16,7 @@ var (
 	errorFile  *os.File
 	initLogger = initZapLogger
 
-	logDir   = "/var/log/api"
+	logDir   = "/var/log/"
 	infoLog  = "info.log"
 	errorLog = "error.log"
 )
@@ -25,6 +25,7 @@ func initZapLogger() {
 	var (
 		err error
 	)
+	logDir += os.Getenv("MODULDE")
 	if _, err = os.Stat(logDir); os.IsNotExist(err) {
 		_ = os.MkdirAll(logDir, os.ModePerm)
 	}

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,7 @@
 {
     "max_retries": 3,
     "try_timeout": 1,
-    "create_transaction_timeout": 3
+    "create_transaction_timeout": 3,
+    "transaction_expiration": 30,
+    "invalidate_interval_minutes": 10
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,22 @@ services:
     depends_on:
       - api_server
 
+  invalidator:
+    build:
+      context: .
+      dockerfile: Dockerfile.invalidator
+    container_name: invalidator
+    environment:
+      - DATABASE_HOST=db
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=example
+      - DATABASE_PORT=5432
+      - MODULDE=invalidator
+    volumes:
+      - ./invalidator_logs:/var/log/invalidator
+    depends_on:
+      db:
+        condition: service_healthy
   api_server:
     build:
       context: .
@@ -23,8 +39,9 @@ services:
       - DATABASE_USER=postgres
       - DATABASE_PASSWORD=example
       - DATABASE_PORT=5432
+      - MODULDE=api
     volumes:
-      - ./logs:/var/log/api
+      - ./api_logs:/var/log/api
     depends_on:
       db:
         condition: service_healthy

--- a/internal/account/tcc.go
+++ b/internal/account/tcc.go
@@ -103,9 +103,7 @@ func (s *tccService) Try(ctx context.Context, transactionID string, sourceAccoun
 		}
 
 		switch fundMovement.Stage {
-		case Confirmed:
-			return nil
-		case Tried:
+		case Confirmed, Tried:
 			return nil
 		case Canceled:
 			return ErrRollbacked

--- a/internal/transaction/repository.go
+++ b/internal/transaction/repository.go
@@ -3,10 +3,13 @@ package transaction
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"main/common/config"
 	"main/model"
 	. "main/model"
 	"time"
 
+	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
@@ -15,6 +18,7 @@ type Repository interface {
 	GetTransactionByID(ctx context.Context, id string) (Transaction, error)
 	UpdateTransactionStatus(ctx context.Context, id string, status model.TransactionStatus) error
 	Transaction(fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error
+	QueryExpiredTransactions(ctx context.Context) ([]model.Transaction, error)
 }
 
 type repository struct {
@@ -28,6 +32,9 @@ func NewRepository(db *gorm.DB) Repository {
 func (r *repository) CreateTransaction(ctx context.Context, transaction Transaction) error {
 	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*2)
 	defer cancel()
+	now := time.Now()
+	// Set expiration time
+	transaction.ExpiredAt = now.Add(time.Minute * time.Duration(viper.GetInt(config.ConfigKeyTransactionExpiration)))
 	return r.db.WithContext(ctxTimeout).Create(&transaction).Error
 }
 
@@ -45,4 +52,23 @@ func (r *repository) UpdateTransactionStatus(ctx context.Context, id string, sta
 
 func (r *repository) Transaction(fc func(tx *gorm.DB) error, opts ...*sql.TxOptions) error {
 	return r.db.Transaction(fc, opts...)
+}
+
+func (r *repository) QueryExpiredTransactions(ctx context.Context) ([]model.Transaction, error) {
+	var count int64
+	if err := r.db.Model(Transaction{}).Where("expired_at < ?", time.Now()).Where("transaction_status in ?", []model.TransactionStatus{Pending, Processing}).Count(&count).Error; err != nil {
+		return nil, err
+	}
+
+	if count > 200 {
+		return nil, errors.New("too many pending/processing transactions")
+	}
+
+	var transactions []model.Transaction
+
+	if err := r.db.Model(Transaction{}).Where("expired_at < ?", time.Now()).Where("transaction_status in ?", []model.TransactionStatus{Pending, Processing}).Offset(0).Limit(200).Find(&transactions).Error; err != nil {
+		return nil, err
+	}
+
+	return transactions, nil
 }

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -23,6 +23,7 @@ type Transaction struct {
 	TransactionStatus    TransactionStatus `gorm:"type:int;not null" json:"transaction_status"`
 	CreatedAt            time.Time         `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt            time.Time         `gorm:"autoUpdateTime" json:"updated_at"`
+	ExpiredAt            time.Time         `gorm:"expired_at" json:"expired_at"`
 	Retries              int               `gorm:"-" json:"-"`
 	TransactionAmount    string            `gorm:"-" json:"transaction_amount,omitempty"`
 }

--- a/sql/create_databases.sql
+++ b/sql/create_databases.sql
@@ -41,7 +41,9 @@ CREATE TABLE IF NOT EXISTS transaction_tab (
     amount BIGINT NOT NULL,
     transaction_status INT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expired_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX idx_transactions_status ON transaction_tab(transaction_status);
+CREATE INDEX idx_transactions_expired_status ON transaction_tab(expired_at, transaction_status);


### PR DESCRIPTION
1. Add an `expired_at` in transaction_tab.
2. Add an index for query expired_at + transaction_status
3. Set above `expired_ad` parameter when create pending transaction, with a expiry time according to configuration.
4. Have a periodical cronjob runs every 10 mins, to load all expired pending and processing transactions, and try to cancel them.